### PR TITLE
add log4php psr-3 wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+coverage.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: php
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
+env:
+  - COMPOSER_OPTS=""
+  - COMPOSER_OPTS="--prefer-lowest"
+before_script:
+  - composer self-update
+  - composer install --no-interaction
+script:
+  - vendor/bin/phing

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
-# psr-log4php
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/abacaphiliac/psr-log4php/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/abacaphiliac/psr-log4php/?branch=master)
+[![Code Coverage](https://scrutinizer-ci.com/g/abacaphiliac/psr-log4php/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/abacaphiliac/psr-log4php/?branch=master)
+[![Build Status](https://travis-ci.org/abacaphiliac/psr-log4php.svg?branch=master)](https://travis-ci.org/abacaphiliac/psr-log4php)
+
+# abacaphiliac/psr-log4php
 A PSR-3-compliant log4php-wrapper.
+
+# Installation
+```bash
+composer require abacaphiliac/psr-log4php
+```
+
+# Usage
+
+```
+$nonPsrLogger = \Logger::getLogger('MyLogger');
+$psrLogger = new \Abacaphiliac\PsrLog4Php\LoggerWrapper($nonPsrLogger);
+```
+
+# Dependencies
+See [composer.json](composer.json).
+
+## Contributing
+```
+composer update && vendor/bin/phing
+```
+
+This library attempts to comply with [PSR-1][], [PSR-2][], and [PSR-4][]. If
+you notice compliance oversights, please send a patch via pull request.
+
+[PSR-1]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md
+[PSR-2]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md
+[PSR-4]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,41 @@
+<project name="abacaphiliac/psr-log4php" default="develop" basedir=".">
+    
+    <target name="develop">
+        <phingcall target="lint"/>
+        <phingcall target="tests"/>
+    </target>
+
+    <target name="lint">
+        <phingcall target="php-lint"/>
+        <phingcall target="phpcs"/>
+    </target>
+
+    <target name="php-lint">
+        <exec command="vendor/bin/parallel-lint src tests"
+              passthru="true"
+              output="/dev/stdout"
+              error="/dev/stdout"
+              checkreturn="true"/>
+    </target>
+
+    <target name="phpcs">
+        <exec command="vendor/bin/phpcs --standard=PSR2 --extensions=php --severity=1 --colors -p src/ tests/"
+              passthru="true"
+              output="/dev/stdout"
+              error="/dev/stdout"
+              checkreturn="true"/>
+    </target>
+    
+    <target name="tests">
+        <phingcall target="unit-tests"/>
+    </target>
+    
+    <target name="unit-tests">
+        <exec command="vendor/bin/phpunit --coverage-text"
+            passthru="true"
+            output="/dev/stdout"
+            error="/dev/stdout"
+            checkreturn="true"/>
+    </target>
+    
+</project>

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,43 @@
+{
+  "name": "abacaphiliac/psr-log4php",
+  "description": "A PSR-3-compliant log4php-wrapper.",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Timothy Younger",
+      "email": "abacaphiliac@gmail.com"
+    }
+  ],
+  "keywords": [
+    "psr",
+    "log4php",
+    "log",
+    "logger",
+    "logging",
+    "apache",
+    "psr-3",
+    "psr3",
+    "fig"
+  ],
+  "require": {
+    "php": ">=5.3",
+    "apache/log4php": "^2.0",
+    "psr/log": "^1.0"
+  },
+  "require-dev": {
+    "jakub-onderka/php-parallel-lint": "^0.9",
+    "phing/phing": "^2.9",
+    "phpunit/phpunit": "^5.4|^4.8",
+    "squizlabs/php_codesniffer": "^2.2"
+  },
+  "autoload": {
+    "psr-4": {
+      "Abacaphiliac\\PsrLog4Php\\": "src/PsrLog4Php"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "AbacaphiliacTest\\PsrLog4Php\\": "tests/PsrLog4Php"
+    }
+  }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,16 @@
+<phpunit bootstrap="vendor/autoload.php"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         disallowChangesToGlobalState="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="abacaphiliac/psr-log4php">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/PsrLog4Php/DefaultFormatter.php
+++ b/src/PsrLog4Php/DefaultFormatter.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Abacaphiliac\PsrLog4Php;
+
+class DefaultFormatter implements FormatterInterface
+{
+    /**
+     * @param mixed $level
+     * @param mixed $message
+     * @param mixed[] $context
+     * @return mixed
+     */
+    public function format($level, $message, array $context = array())
+    {
+        if (is_string($message)) {
+            return $message . ' ' . json_encode($context);
+        }
+
+        // Cannot append encoded context without causing an error, or blocking log4php object renderers.
+        return $message;
+    }
+}

--- a/src/PsrLog4Php/FormatterInterface.php
+++ b/src/PsrLog4Php/FormatterInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Abacaphiliac\PsrLog4Php;
+
+interface FormatterInterface
+{
+    /**
+     * @param mixed $level
+     * @param mixed $message
+     * @param mixed[] $context
+     * @return mixed
+     */
+    public function format($level, $message, array $context = array());
+}

--- a/src/PsrLog4Php/LoggerWrapper.php
+++ b/src/PsrLog4Php/LoggerWrapper.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Abacaphiliac\PsrLog4Php;
+
+use Psr\Log\AbstractLogger;
+use Psr\Log\LogLevel;
+
+class LoggerWrapper extends AbstractLogger
+{
+    /** @var \Logger */
+    private $logger;
+    
+    /** @var DefaultFormatter */
+    private $formatter;
+
+    /** @var int[] */
+    private $levels;
+    
+    /** @var string */
+    private $defaultLevel;
+
+    /**
+     * Log4PhpPsr3Wrapper constructor.
+     * @param \Logger $logger
+     * @param FormatterInterface $formatter
+     * @param int[] $levels
+     * @param string $defaultLevel
+     */
+    public function __construct(
+        \Logger $logger,
+        FormatterInterface $formatter = null,
+        array $levels = array(),
+        $defaultLevel = LogLevel::ERROR
+    ) {
+        if (!$formatter) {
+            $formatter = new DefaultFormatter();
+        }
+        
+        if (!$levels) {
+            $levels = array(
+                LogLevel::EMERGENCY => \LoggerLevel::FATAL,
+                LogLevel::ALERT => \LoggerLevel::FATAL,
+                LogLevel::CRITICAL => \LoggerLevel::FATAL,
+                LogLevel::ERROR => \LoggerLevel::ERROR,
+                LogLevel::WARNING => \LoggerLevel::WARN,
+                LogLevel::NOTICE => \LoggerLevel::WARN,
+                LogLevel::INFO => \LoggerLevel::INFO,
+                LogLevel::DEBUG => \LoggerLevel::DEBUG,
+            );
+        }
+        
+        $this->logger = $logger;
+        $this->formatter = $formatter;
+        $this->levels = $levels;
+        $this->defaultLevel = $defaultLevel;
+    }
+
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @param mixed $level
+     * @param mixed $message
+     * @param mixed[] $context
+     * @return null
+     */
+    public function log($level, $message, array $context = array())
+    {
+        if (!array_key_exists($level, $this->levels)) {
+            $level = $this->defaultLevel;
+        }
+        
+        $level = \LoggerLevel::toLevel($this->levels[$level], $this->defaultLevel);
+        
+        $message = $this->formatter->format($level, $message, $context);
+
+        $this->logger->log($level, $message);
+    }
+}

--- a/tests/PsrLog4Php/DefaultFormatterTest.php
+++ b/tests/PsrLog4Php/DefaultFormatterTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace AbacaphiliacTest\PsrLog4Php;
+
+use Abacaphiliac\PsrLog4Php\DefaultFormatter;
+use Psr\Log\LogLevel;
+
+class DefaultFormatterTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var DefaultFormatter */
+    private $sut;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->sut = new DefaultFormatter();
+    }
+    
+    public function testFormatString()
+    {
+        $actual = $this->sut->format(LogLevel::INFO, 'FooBar', array('Fizz' => 'Buzz'));
+        
+        self::assertContains('FooBar', $actual);
+        self::assertContains('Fizz', $actual);
+        self::assertContains('Buzz', $actual);
+    }
+    
+    public function testFormatNonString()
+    {
+        $actual = $this->sut->format(LogLevel::INFO, $expected = new \stdClass(), array('Fizz' => 'Buzz'));
+        
+        self::assertSame($expected, $actual);
+    }
+}

--- a/tests/PsrLog4Php/FooBar.php
+++ b/tests/PsrLog4Php/FooBar.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace AbacaphiliacTest\PsrLog4Php;
+
+class FooBar
+{
+    /** @var string */
+    private $value;
+
+    /**
+     * FooBar constructor.
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/tests/PsrLog4Php/FooBarRenderer.php
+++ b/tests/PsrLog4Php/FooBarRenderer.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace AbacaphiliacTest\PsrLog4Php;
+
+class FooBarRenderer implements \LoggerRenderer
+{
+    /**
+     * Renders the entity passed as <var>input</var> to a string.
+     * @param mixed $input The entity to render.
+     * @return string The rendered string.
+     */
+    public function render($input)
+    {
+        if ($input instanceof FooBar) {
+            return $input->getValue();
+        }
+        
+        return '';
+    }
+}

--- a/tests/PsrLog4Php/LoggerWrapperTest.php
+++ b/tests/PsrLog4Php/LoggerWrapperTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace AbacaphiliacTest\PsrLog4Php;
+
+use Abacaphiliac\PsrLog4Php\LoggerWrapper;
+use Psr\Log\LogLevel;
+
+/**
+ * @covers \Abacaphiliac\PsrLog4Php\LoggerWrapper
+ */
+class LoggerWrapperTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \PHPUnit_Framework_MockObject_MockObject|\Logger */
+    private $logger;
+    /** @var LoggerWrapper */
+    private $sut;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->logger = $this->getMockBuilder('\Logger')->disableOriginalConstructor()->getMock();
+        
+        $this->sut = new LoggerWrapper($this->logger);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function dataLog()
+    {
+        return array(
+            'emergency' => array('emergency', \LoggerLevel::getLevelFatal()),
+            'alert' => array('alert', \LoggerLevel::getLevelFatal()),
+            'critical' => array('critical', \LoggerLevel::getLevelFatal()),
+            'error' => array('error', \LoggerLevel::getLevelError()),
+            'warning' => array('warning', \LoggerLevel::getLevelWarn()),
+            'notice' => array('notice', \LoggerLevel::getLevelWarn()),
+            'info' => array('info', \LoggerLevel::getLevelInfo()),
+            'debug' => array('debug', \LoggerLevel::getLevelDebug()),
+        );
+    }
+
+    /**
+     * @dataProvider dataLog
+     * @param string $method
+     * @param string $level
+     */
+    public function testLog($method, $level)
+    {
+        $message = 'FooBar';
+        $context = array('Foo' => 'Bar');
+        
+        $this->logger->expects(self::once())->method('log')
+            ->with($level, self::isType('string'));
+        
+        $this->sut->{$method}($message, $context);
+    }
+    
+    public function testPsrLogLevelIsMapped()
+    {
+        $this->logger->expects(self::once())->method('log')
+            ->with(\LoggerLevel::getLevelFatal(), self::isType('string'));
+
+        $this->sut->log(LogLevel::EMERGENCY, 'FooBar', array('Foo' => 'Bar'));
+    }
+    
+    public function testInvalidLogLevelIsMappedToDefault()
+    {
+        $this->logger->expects(self::once())->method('log')
+            ->with(\LoggerLevel::getLevelError(), self::isType('string'));
+
+        $this->sut->log('InvalidLevel', 'FooBar', array('Foo' => 'Bar'));
+    }
+    
+    public function testLogExceptionViaRenderer()
+    {
+        \Logger::configure(array(
+            'appenders' => array(
+                'echo' => array(
+                    'class' => '\LoggerAppenderEcho',
+                ),
+            ),
+            'rootLogger' => array(
+                'level' => 'ERROR',
+                'appenders' => array(
+                    'echo',
+                ),
+            ),
+            'renderers' => array(
+                'Exception' => array(
+                    'renderedClass' => 'AbacaphiliacTest\PsrLog4Php\FooBar',
+                    'renderingClass' => 'AbacaphiliacTest\PsrLog4Php\FooBarRenderer',
+                ),
+            ),
+        ), new \LoggerConfiguratorDefault());
+        
+        $logger = \Logger::getLogger(__METHOD__);
+        
+        $sut = new LoggerWrapper($logger);
+        
+        ob_start();
+        $sut->error(new FooBar('FizzBuzz'));
+        $actual = ob_get_clean();
+        
+        self::assertEquals("ERROR - FizzBuzz\n", $actual);
+    }
+}


### PR DESCRIPTION
add log4php psr-3 wrapper, with default context formatter. level-map, default-level, and formatter all have opinionated defaults and can be overridden.
